### PR TITLE
Remove AUTHENTICATION_REQUIRED error code

### DIFF
--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -1307,20 +1307,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Client does not have sufficient permission

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -360,20 +360,14 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+
     Generic403:
       description: Forbidden
       headers:

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -432,7 +432,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     And the response header "Content-Type" is "application/json"
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_creation_401.2_expired_access_token
@@ -443,7 +443,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_creation_401.3_malformed_access_token
@@ -454,7 +454,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.4_no_authorization_header
@@ -464,7 +464,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.5_expired_access_token
@@ -474,7 +474,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_401.6_malformed_access_token
@@ -484,7 +484,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.7_no_authorization_header
@@ -494,7 +494,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.8_expired_access_token
@@ -504,7 +504,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_delete_401.9_malformed_access_token
@@ -514,7 +514,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve__list_401.10_no_authorization_header
@@ -524,7 +524,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_list_401.11_expired_access_token
@@ -534,7 +534,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @roaming_status_subscriptions_retrieve_list_401.12_malformed_access_token
@@ -544,7 +544,7 @@ Feature: Device Roaming Status Subscriptions API, v0.7.0 - Operations createDevi
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
 ##################

--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -517,7 +517,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @roaming_status_subscriptions_retrieve__list_401.10_no_authorization_header
+  @roaming_status_subscriptions_retrieve_list_401.10_no_authorization_header
   Scenario: No Authorization header
     Given the request header "Authorization" is removed
     When the request "deleteDeviceRoamingStatusSubscriptionList" is sent

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -160,7 +160,7 @@ Feature: CAMARA Device Roaming Status API, v1.0.0 - Operation getRoamingStatus
     When the request "getRoamingStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @device_roaming_status_401.2_no_authorization_header
@@ -170,7 +170,7 @@ Feature: CAMARA Device Roaming Status API, v1.0.0 - Operation getRoamingStatus
     When the request "getRoamingStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @device_roaming_status_401.3_malformed_access_token
@@ -181,7 +181,7 @@ Feature: CAMARA Device Roaming Status API, v1.0.0 - Operation getRoamingStatus
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
 #################


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities pre-release [r3.1](https://github.com/camaraproject/Commonalities/releases/tag/r3.1) removes the `AUTHENTICATION_REQUIRED` error code, leaving `UNAUTHENTICATED` as the only valid error code when the HTTP status code is 401.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #6 

#### Special notes for reviewers:
This is not a breaking change

#### Changelog input
```
 release-note
 - Remove AUTHENTICATION_REQUIRED error code
```

#### Additional documentation 
None