### PR TITLE
Make lastStatusTime mandatory in 200 responses of the API

### DIFF
--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -27,7 +27,7 @@ info:
 
     * **Country** : Country code and name - visited country information, provided if the device is in roaming situation.
 
-    * **LastStatusTime** : This property specifies the time when the status was last updated. Its presence in the response indicates the freshness of the information, while its absence implies the information may be outdated or its freshness is uncertain.
+    * **LastStatusTime** : The time when the status was last confirmed to be correct. An older status is more likely to now be incorrect.
 
     # API Functionality
 
@@ -182,6 +182,7 @@ components:
     RoamingStatusResponse:
       type: object
       required:
+        - lastStatusTime
         - roaming
       properties:
         lastStatusTime:

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -35,7 +35,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.roaming" is "true"
     And the response property "$.countryCode" has the value "262" as the Mobile Country Code (MCC) for Germany
     And the response property "$.countryName" is a non-empty array containing the ISO 3166 ALPHA-2 country-code ["DE"]
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
 
   @device_roaming_status_02_roaming_status_false
   Scenario: Check the roaming state synchronously if the device is not in the roaming mode
@@ -50,7 +50,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.roaming" is "false"
     And the response property "$.countryCode" is not present
     And the response property "$.countryName" is not present
-    And if the response property "$.lastStatusTime" is present, then the value is a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
 
 #################
 # Error scenarios for management of input parameter device


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
This PR makes property `lastStatusTime` mandatory in 200 responses of the API

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #12 

#### Special notes for reviewers:
This is not a breaking change for the client

#### Changelog input
```
 release-note
 - Make lastStatusTime mandatory in 200 responses of the API
```

#### Additional documentation 
None