### PR TITLE
Fix incorrect type values in the subscription test definitions

### DIFF
--- a/code/Test_definitions/device-roaming-status-subscriptions.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions.feature
@@ -555,7 +555,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
   Scenario: subscription creation without having the required scope
     Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
+    And the request body property "$.types" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -566,7 +566,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
   Scenario: subscription creation without having the required scope
     Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off"
+    And the request body property "$.types" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-off"
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -577,7 +577,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
   Scenario: subscription creation without having the required scope
     Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
+    And the request body property "$.types" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-status"
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403
@@ -588,7 +588,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operations createDevice
   Scenario: subscription creation without having the required scope
     Given the header "Authorization" set to an access token not including scope "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the request body property "$.types" is equal to "device-roaming-status-subscriptions:org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country"
+    And the request body property "$.types" is equal to "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-change-country"
     When the request "createDeviceRoamingStatusSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403


### PR DESCRIPTION
#### What type of PR is this?
* bug

#### What this PR does / why we need it:
Fixes incorrect type values in the subscription test definitions

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #9 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Fix incorrect type values in the subscription test definitions
```

#### Additional documentation 
None