### PR TITLE
Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code

### DIFF
--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -13,7 +13,10 @@ info:
     # Relevant terms and definitions
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
-      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier (not supported for this API version) assigned by the mobile network operator for the device.
+
+        At least one identifier for the device out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     # API Functionality
 
@@ -231,8 +234,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
               examples:
-                subscription-active:
-                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVE"
+                Active Subscription:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION"
+                Active Subscription With Device Disambiguation:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION"
         "202":
           description: Request accepted to be processed. It applies for async creation process.
           headers:
@@ -310,11 +315,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
               examples:
-                subscription-active:
-                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVE"
-                subscription-activation-requested:
+                Active Subscription:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION"
+                Active Subscription With Device Disambiguation:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION"
+                Subscription Activation Requested:
                   $ref: "#/components/examples/SUBSCRIPTION_ACTIVATION_REQUESTED"
-                subscription-deleted:
+                Subscription Deleted:
                   $ref: "#/components/examples/SUBSCRIPTION_DELETED"
         "400":
           $ref: "#/components/responses/SubscriptionIdRequired400"
@@ -1476,19 +1483,12 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
                       - MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:
@@ -1623,7 +1623,23 @@ components:
           subscriptionId: qs15-h556-rt89-1298
         time: "2023-01-19T13:18:23.682Z"
 
-    SUBSCRIPTION_ACTIVE:
+    ACTIVE_SUBSCRIPTION:
+      value:
+        id: 550e8400-e29b-41d4-a716-446655440000
+        sink: https://endpoint.example.com/sink
+        protocol: HTTP
+        types:
+          - "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
+        config:
+          subscriptionDetail:
+          subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        startsAt: "2024-07-03T21:12:02.871Z"
+        expiresAt: "2024-07-03T21:12:02.871Z"
+        status: ACTIVE
+
+    ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION:
       value:
         id: 550e8400-e29b-41d4-a716-446655440000
         sink: https://endpoint.example.com/sink
@@ -1650,8 +1666,6 @@ components:
           - "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
         config:
           subscriptionDetail:
-            device:
-              phoneNumber: "+123456789"
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true
@@ -1668,8 +1682,6 @@ components:
           - "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
         config:
           subscriptionDetail:
-            device:
-              phoneNumber: "+123456789"
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -284,6 +284,11 @@ paths:
                 minItems: 0
                 items:
                   $ref: '#/components/schemas/Subscription'
+              examples:
+                List of Subscriptions:
+                  $ref: "#/components/examples/SUBSCRIPTION_LIST"
+                Empty List of Subscriptions:
+                  $ref: "#/components/examples/EMPTY_SUBSCRIPTION_LIST"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -1712,3 +1717,24 @@ components:
           "subscriptionMaxEvents": 5,
           "initialEvent": true
         }
+
+    SUBSCRIPTION_LIST:
+      description: A list of API consumer subscriptions. If a 3-legged access token is used, the list is specific to the device associated with that token.
+      value:
+      - id: 550e8400-e29b-41d4-a716-446655440000
+        sink: https://endpoint.example.com/sink
+        protocol: HTTP
+        types:
+          - "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
+        config:
+          subscriptionDetail: {}
+          subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        startsAt: "2024-07-03T21:12:02.871Z"
+        expiresAt: "2024-07-03T21:12:02.871Z"
+        status: ACTIVE
+
+    EMPTY_SUBSCRIPTION_LIST:
+      description: The API consumer either has no subscriptions or, if a 3-legged access token is used, has none for the device associated with that token.
+      value: {}

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -1631,7 +1631,7 @@ components:
         types:
           - "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
         config:
-          subscriptionDetail:
+          subscriptionDetail: {}
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true
@@ -1665,7 +1665,7 @@ components:
         types:
           - "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
         config:
-          subscriptionDetail:
+          subscriptionDetail: {}
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true
@@ -1681,7 +1681,7 @@ components:
         types:
           - "org.camaraproject.device-roaming-status-subscriptions.v0.roaming-on"
         config:
-          subscriptionDetail:
+          subscriptionDetail: {}
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -17,11 +17,12 @@ info:
       - For security / fraud reasons, to establish that a customer is located where they claim to be
       - For service delivery reasons, to ensure that the customer has access to particular service, and will not incur roaming charges in accessing them
 
-
     ## Relevant terms and definitions
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
-      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier (not supported for this API version) assigned by the mobile network operator for the device.
+      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Roaming** : Roaming status - `true`, if device is in roaming situation - `false` else.
 
@@ -124,6 +125,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/RoamingStatusResponse"
               examples:
+                Not Roaming:
+                  value:
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
+                    roaming: false
                 No-Country-Name:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
@@ -132,6 +137,14 @@ paths:
                     countryName: []
                 Single-Country-Code:
                   value:
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
+                    roaming: true
+                    countryCode: 262
+                    countryName: ["DE"]
+                Single Country Code With Device Disambiguation:
+                  value:
+                    device:
+                      phoneNumber: "+123456789"
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 262
@@ -185,6 +198,8 @@ components:
         - lastStatusTime
         - roaming
       properties:
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
         lastStatusTime:
           $ref: "#/components/schemas/LastStatusTime"
         roaming:
@@ -227,6 +242,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
@@ -443,18 +468,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -20,7 +20,8 @@ info:
     ## Relevant terms and definitions
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
-      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        At least one identifier for the device (user equipment) out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
 
         Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
@@ -129,13 +130,13 @@ paths:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: false
-                No-Country-Name:
+                No Country Name:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true
                     countryCode: 901
                     countryName: []
-                Single-Country-Code:
+                Single Country Code:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true
@@ -149,7 +150,7 @@ paths:
                     roaming: true
                     countryCode: 262
                     countryName: ["DE"]
-                Multiple-Country-Codes:
+                Multiple Country Codes:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -136,19 +136,6 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @device_roaming_status_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "getRoamingStatus" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 #################
 # Error code 401
 #################


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities has removed the `IDENTIFIER_MISMATCH` error for Fall25. Instead, a device identifier should not normally be included in responses. It should only be included to disambiguate the identity of the device when:
- the endpoint is being accessed using a 2-legged access token; and
- the endpoint allows for a device identifier to be provided in the request; and
- the API consumer has included multiple device identifiers

The response then includes the device identifier that was used by the implementation

This PR:
- Updates documentation in each OAS
- Adds relevant examples both for when device disambiguation is required, and when it is not required
- Uses `DeviceResponse` object in for the device-status API to limit device identifiers in responses to exactly one
- Removes the IDENTIFIER_MISMATCH error code option from 422 responses

Note; For subscriptions, the `CreateSubscriptionDetail` schema is used in both requests and responses, so modifying the responses to use the `DeviceResponse` would require a general update of the subscription schema in Commonalities. For the moment, the existing schema is left unmodified, which means that multiple device identifiers could be provided in responses, but should not.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:
I think both GET endpoints should never return a device identifier in the responses, but haven't thought through all possible scenarios, so will raise this as a separate issue.

#### Changelog input

```
 release-note
 - Update documentation in each OAS
 - Add relevant examples both for when device disambiguation is required, and when it is not required
 - Use DeviceResponse object in for the device-status API to limit device identifiers in responses to exactly one
 - Remove the IDENTIFIER_MISMATCH error code option from 422 responses
```

#### Additional documentation 
None