### PR TITLE
Release r1.2 (Fall'25 M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog DeviceRoamingStatus
 ## Table of Contents
+- [r1.2](#r12)
 - [r1.1](#r11)
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
@@ -12,6 +13,70 @@ The below sections record the changes for each API version in each release as fo
   - for a public release, the consolidated changes since the previous public release
 
 Note: this API had former releases in the [DeviceStatus](https://github.com/camaraproject/DeviceStatus) repository
+
+# r1.2
+## Release Notes
+
+This public release contains the definition and documentation of
+* device-roaming-status v1.1.0
+* device-roaming-status-subscriptions v0.8.0
+
+The API definition(s) are based on
+* Commonalities v0.6.0 (r3.3)
+* Identity and Consent Management v0.4.0 (r3.3)
+
+## device-roaming-status v1.1.0
+device-roaming-status v1.1.0 is a minor update of the API, and is backward compatible with v1.0.0.
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceRoamingStatus/blob/r1.2/code/API_definitions/device-roaming-status.yaml)
+
+### Added
+
+### Changed
+* Make lastStatusTime mandatory in 200 responses of the API by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/19
+* Update error response documentation in OAS definitions by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/30
+* Update x-correlator schema by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/29
+* Commonalities alignement for device roaming status by @bigludo7 in https://github.com/camaraproject/DeviceRoamingStatus/pull/37
+* Update error schema for compliance with Commonalities r3.3 by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/45
+* admin: migrate to centralized linting workflows by @hdamker-bot in https://github.com/camaraproject/DeviceRoamingStatus/pull/41
+
+### Fixed
+* Fix feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/42
+
+### Removed
+* Remove AUTHENTICATION_REQUIRED error code by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/14
+* Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/22
+
+## device-roaming-status-subscriptions v0.8.0
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status-subscriptions.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status-subscriptions.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceRoamingStatus/blob/r1.2/code/API_definitions/device-roaming-status-subscriptions.yaml)
+
+### Added
+* Add subscription started & updated event by @bigludo7 in https://github.com/camaraproject/DeviceRoamingStatus/pull/35
+
+### Changed
+* change sink format to format: uri by @maxl2287 in https://github.com/camaraproject/DeviceRoamingStatus/pull/18
+* Rename subscription-ends event to subscription-ended by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/31
+* Update error response documentation in OAS definitions by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/30
+* Update x-correlator schema by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/29
+* Commonalities alignement for device roaming subscription by @bigludo7 in https://github.com/camaraproject/DeviceRoamingStatus/pull/37
+* Update error schema for compliance with Commonalities r3.3 by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/45
+* admin: migrate to centralized linting workflows by @hdamker-bot in https://github.com/camaraproject/DeviceRoamingStatus/pull/41
+
+### Fixed
+* remove "Generic High Entropy Secret" by @maxl2287 in https://github.com/camaraproject/DeviceRoamingStatus/pull/17
+* Fix feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/42
+
+### Removed
+* Remove AUTHENTICATION_REQUIRED error code by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/14
+* Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/22
+
+**Full Changelog**: https://github.com/camaraproject/DeviceRoamingStatus/commits/r1.2
+
 # r1.1
 ## Release Notes
 
@@ -73,4 +138,3 @@ device-roaming-status v1.1.0 will be a minor update of the API, and is backward 
 * Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/DeviceRoamingStatus/pull/22
 
 **Full Changelog**: https://github.com/camaraproject/DeviceRoamingStatus/commits/r1.1
-

--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ Incubating API Repository to evolve and maintain the definitions and documentati
 
 ## Release Information
 
-The latest public release of the Device Status repository, including the DeviceRoamingStatus API, is available here: https://github.com/camaraproject/DeviceStatus/releases/latest
-<!-- Optional: an explicit listing of the latest (pre-)release with additional information, e.g. links to the API definitions -->
-<!-- In addition use/uncomment one or multiple the following alternative options when becoming applicable -->
-Pre-releases of this sub project are available in https://github.com/camaraproject/DeviceRoamingStatus/releases
-<!-- The latest public release is available here: https://github.com/camaraproject/DeviceRoamingStatus/releases/latest -->
-<!-- For changes see [CHANGELOG.md](https://github.com/camaraproject/DeviceRoamingStatus/blob/main/CHANGELOG.md) -->
+The latest public release of the DeviceRoamingStatus repository is available [here](https://github.com/camaraproject/DeviceRoamingStatus/releases/latest)
+
+  * **device-roaming-status v1.1.0**  
+  [[YAML]](https://github.com/camaraproject/DeviceRoamingStatus/blob/r1.2/code/API_definitions/device-roaming-status.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status.yaml)
+  * **device-roaming-status-subscriptions v0.8.0**  
+  [[YAML]](https://github.com/camaraproject/DeviceRoamingStatus/blob/r1.2/code/API_definitions/device-roaming-status-subscriptions.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status-subscriptions.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceRoamingStatus/r1.2/code/API_definitions/device-roaming-status-subscriptions.yaml)
+
+Pre-releases of this sub project are available [here](https://github.com/camaraproject/DeviceRoamingStatus/releases). For changes see the [change log](https://github.com/camaraproject/DeviceRoamingStatus/blob/main/CHANGELOG.md).
 
 ## Contributing
 

--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -144,14 +144,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 0.8.0
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/device-roaming-status-subscriptions/vwip"
+  - url: "{apiRoot}/device-roaming-status-subscriptions/v0.8"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -86,14 +86,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 1.1.0
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/device-roaming-status/vwip"
+  - url: "{apiRoot}/device-roaming-status/v1"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/device-roaming-status-subscriptions-deleteDeviceRoamingStatusSubscription.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions-deleteDeviceRoamingStatusSubscription.feature
@@ -14,7 +14,7 @@ Feature: Device Roaming Status Subscriptions API, v0.8.0 - Operation deleteDevic
   # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml
 
   Background: Common Device Roaming Status Subscriptions setup
-    Given the resource "{apiroot}/device-roaming-status-subscriptions/v0.8" as base-url
+    Given the resource "{apiroot}/device-roaming-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-roaming-status-subscriptions-deleteDeviceRoamingStatusSubscription.feature
+++ b/code/Test_definitions/device-roaming-status-subscriptions-deleteDeviceRoamingStatusSubscription.feature
@@ -1,5 +1,5 @@
 # device-status-roaming-subscriptions-deleteDeviceRoamingStatusSubscription
-Feature: Device Roaming Status Subscriptions API, vwip - Operation deleteDeviceRoamingStatusSubscription
+Feature: Device Roaming Status Subscriptions API, v0.8.0 - Operation deleteDeviceRoamingStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -14,7 +14,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operation deleteDeviceR
   # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml
 
   Background: Common Device Roaming Status Subscriptions setup
-    Given the resource "{apiroot}/device-roaming-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-roaming-status-subscriptions/v0.8" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -1,5 +1,5 @@
 # device-roaming-status
-Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
+Feature: CAMARA Device Roaming Status API, v1.1.0 - Operation getRoamingStatus
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -12,7 +12,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
   # References to OAS spec schemas refer to schemas specifies in device-roaming-status.yaml
 
   Background: Common getRoamingStatus setup
-    Given the resource "{api-root}/device-roaming-status/vwip/retrieve" set as base-url
+    Given the resource "{api-root}/device-roaming-status/v1/retrieve" set as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/device-status-roaming-subscriptions-createDeviceRoamingStatusSubscription.feature
+++ b/code/Test_definitions/device-status-roaming-subscriptions-createDeviceRoamingStatusSubscription.feature
@@ -1,5 +1,5 @@
 # device-status-roaming-subscriptions-createDeviceRoamingStatusSubscription
-Feature: Device Roaming Status Subscriptions API, vwip - Operation createDeviceRoamingStatusSubscription
+Feature: Device Roaming Status Subscriptions API, v0.8.0 - Operation createDeviceRoamingStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -14,7 +14,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operation createDeviceR
   # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml
 
   Background: Common Device Roaming Status Subscriptions setup
-    Given the resource "{apiroot}/device-roaming-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-roaming-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"

--- a/code/Test_definitions/device-status-roaming-subscriptions-retrieveDeviceRoamingStatusSubscription.feature
+++ b/code/Test_definitions/device-status-roaming-subscriptions-retrieveDeviceRoamingStatusSubscription.feature
@@ -1,5 +1,5 @@
 # device-status-roaming-subscriptions-retrieveDeviceRoamingStatusSubscription
-Feature: Device Roaming Status Subscriptions API, vwip - Operation retrieveDeviceRoamingStatusSubscription
+Feature: Device Roaming Status Subscriptions API, v0.8.0 - Operation retrieveDeviceRoamingStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -14,7 +14,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operation retrieveDevic
   # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml
 
   Background: Common Device Roaming Status Subscriptions setup
-    Given the resource "{apiroot}/device-roaming-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-roaming-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-status-roaming-subscriptions-retrieveDeviceRoamingStatusSubscriptionList.feature
+++ b/code/Test_definitions/device-status-roaming-subscriptions-retrieveDeviceRoamingStatusSubscriptionList.feature
@@ -1,5 +1,5 @@
 # device-status-roaming-subscriptions-retrieveDeviceRoamingStatusSubscriptionList
-Feature: Device Roaming Status Subscriptions API, vwip - Operation retrieveDeviceRoamingStatusSubscriptionList
+Feature: Device Roaming Status Subscriptions API, v0.8.0 - Operation retrieveDeviceRoamingStatusSubscriptionList
 
   # Input to be provided by the implementation to the tester
   #
@@ -14,7 +14,7 @@ Feature: Device Roaming Status Subscriptions API, vwip - Operation retrieveDevic
   # References to OAS spec schemas refer to schemas specified in device-roaming-status-subscriptions.yaml
 
   Background: Common Device Roaming Status Subscriptions setup
-    Given the resource "{apiroot}/device-roaming-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-roaming-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/documentation/API_documentation/device-roaming-status-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/device-roaming-status-API-Readiness-Checklist.md
@@ -1,22 +1,22 @@
 # API Readiness Checklist
 
-Checklist for device-roaming-status 1.1.0-rc.2 in r1.1.
+Checklist for device-roaming-status 1.1.0 in r1.2.
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [/code/API_definitions/device-roaming-status.yaml](/code/API_definitions/device-roaming-status.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/Commonalities/releases/tag/r3.2)     |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2)     |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | inline in YAML |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |  Y    |   [/documentation/API_documentation/device-roaming-status-User-Story.md](/documentation/API_documentation/device-roaming-status-User-Story.md)   |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   Y | [/code/Test_definitions/device-roaming-status.feature](/code/Test_definitions/device-roaming-status.feature) |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   Y   |  [/code/Test_definitions/device-roaming-status.feature](/code/Test_definitions/device-roaming-status.feature)   |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |   Y   |  na  |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |      |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y   | [/CHANGELOG.md](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |   Y   |   see (1)   |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/vYBmBQ) |
+|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y  | [/code/API_definitions/device-roaming-status.yaml](/code/API_definitions/device-roaming-status.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.3)     |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.3)     |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y  |      |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y  | inline in YAML |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |   Y  | [/documentation/API_documentation/device-roaming-status-User-Story.md](/documentation/API_documentation/device-roaming-status-User-Story.md)   |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   Y  | [/code/Test_definitions/device-roaming-status.feature](/code/Test_definitions/device-roaming-status.feature) |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   Y  | [/code/Test_definitions/device-roaming-status.feature](/code/Test_definitions/device-roaming-status.feature)   |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |   Y  | na  |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y  |     |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y  | [/CHANGELOG.md](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |   Y  | see (1)   |
+| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |   Y  | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/vYBmBQ) |
 
 (1) GSMA certified implementations of previous version by multiple operators (source: https://open-gateway.gsma.com/map as of 2025-03-11)
 

--- a/documentation/API_documentation/device-roaming-status-subscriptions-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/device-roaming-status-subscriptions-API-Readiness-Checklist.md
@@ -1,21 +1,21 @@
 # API Readiness Checklist
 
-Checklist for device-roaming-status-subscriptions 0.8.0-rc.1 in r1.1.
+Checklist for device-roaming-status-subscriptions 0.8.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [/code/API_definitions/device-roaming-status-subscriptions.yaml](/code/API_definitions/device-roaming-status-subscriptions.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/Commonalities/releases/tag/r3.2)    |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2)    |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | inline in YAML |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |  N    |      |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   Y | [/code/Test_definitions/device-roaming-status-subscriptions.feature](/code/Test_definitions/device-roaming-status-subscriptions.feature) |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N   |     |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |   N   |     |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |      |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y   | [/CHANGELOG.md](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |   N   |      |
+|  1 | API definition                               |   M   |         M         |    M    |    M   |  Y   | [/code/API_definitions/device-roaming-status-subscriptions.yaml](/code/API_definitions/device-roaming-status-subscriptions.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.3)    |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.3)    |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |  Y   |      |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |  Y   | inline in YAML |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |  N   |      |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |  Y   | [/code/Test_definitions/device-roaming-status-subscriptions.feature](/code/Test_definitions/device-roaming-status-subscriptions.feature) |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |  N   |      |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |  N   |      |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |  Y   |      |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |  Y   | [/CHANGELOG.md](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |  N   |      |
 | 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/D4FlBQ) |
 
 Note: the checklists of a public API version and of its preceding release-candidate API version can be the same.


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
Publication of Fall'25 M4 public release of:
- device-roaming-status v1.1.0
- device-roaming-status-subscriptions v0.8.0

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #40

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Publication of Fall'25 M4 public release of device-roaming-status v1.1.0 and device-roaming-status-subscriptions v0.8.0
```

#### Additional documentation 
None