### PR TITLE
Add examples for roaming status retrieval

### DIFF
--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -145,6 +145,7 @@ paths:
                 summary: Device not provided
                 description: The device has to be deducted from token
                 value:
+                  {}
         required: true
       responses:
         "200":

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -120,6 +120,31 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/RoamingStatusRequest"
+            examples:
+              INPUT_PHONE_NUMBER:
+                summary: Phone number
+                description: Retrieve roaming status for a device identified by a phone number
+                value:
+                  device:
+                    phoneNumber: "+123456789"
+              INPUT_IP_ADDRESS_V4:
+                summary: IPv4 address
+                description: Retrieve roaming status for a device identified by an IPv4 address
+                value:
+                  device:
+                    ipv4Address:
+                      publicAddress: 123.234.1.2
+                      publicPort: 1234
+              INPUT_IP_ADDRESS_V6:
+                summary: IPv6 address
+                description: Retrieve roaming status for a device identified by an IPv6 address
+                value:
+                  device:
+                    ipv6Address: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+              INPUT_NO_DEVICE:
+                summary: Device not provided
+                description: The device has to be deducted from token
+                value:
         required: true
       responses:
         "200":

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -133,7 +133,7 @@ paths:
                 value:
                   device:
                     ipv4Address:
-                      publicAddress: 123.234.1.2
+                      publicAddress: "123.234.1.2"
                       publicPort: 1234
               INPUT_IP_ADDRESS_V6:
                 summary: IPv6 address

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -140,7 +140,7 @@ paths:
                 description: Retrieve roaming status for a device identified by an IPv6 address
                 value:
                   device:
-                    ipv6Address: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+                    ipv6Address: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
               INPUT_NO_DEVICE:
                 summary: Device not provided
                 description: The device has to be deducted from token


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:

* correction
* documentation



#### What this PR does / why we need it:

Added examples for retrieving roaming status based on phone number, IPv4, and IPv6 addresses in the device-roaming-status.yaml file.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #38 

#### Special notes for reviewers:

Not a breaking change.


#### Changelog input

```
 release-note
- Added examples for retrieving roaming status based on phone number, IPv4, and IPv6 addresses in the device-roaming-status.yaml file.

```

#### Additional documentation 

This section can be blank.



```
docs

```
