### PR TITLE
Fix example label: Multiple Country Codes → Multiple Country Names

### DIFF
--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -156,7 +156,7 @@ paths:
                     roaming: true
                     countryCode: 262
                     countryName: ["DE"]
-                Multiple Country Codes:
+                Multiple Country Names:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     roaming: true


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction
* documentation



#### What this PR does / why we need it:

The current example in the API specification for device-roaming response uses the label “Multiple Country Codes”, but the actual data shows multiple country names for a single country code:


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #52

#### Special notes for reviewers:

Not a breaking change.


#### Changelog input

```
 release-note
- Update the label in the example to “Multiple Country Names” to accurately reflect the data shown..

```

#### Additional documentation 

This section can be blank.



```
docs

```
