### PR TITLE
Clarify LastStatusTime schema description in YAML

### DIFF
--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -214,7 +214,7 @@ components:
 
     LastStatusTime:
       description: |
-        The last time that the device roaming status was confirmed to be correct by the API provider. It might not be possible to provide the current status becuase, for example, the device may not be connected to any mobile network.
+        The last time that the device roaming status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       type: string
       format: date-time


### PR DESCRIPTION
Updated the description of LastStatusTime to clarify its meaning and potential limitations.

#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Current description refers to reachability rather than roaming status, is slightly ambiguous, and includes formatting recommendations no longer required by Commonalities

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #55 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Clarify LastStatusTime schema description in YAML
```

#### Additional documentation 
None