### PR TITLE
Update release plan for Sync26

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,39 +10,39 @@ repository:
   # Options: independent (default) | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Fall25
+  meta_release: Sync26
 
   # Target CAMARA release tag.
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.2
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: device-roaming-status-subscriptions
-    target_api_version: 0.8.0
-    target_api_status: public
+    target_api_version: 0.9.0
+    target_api_status: rc
     main_contacts:
       - eric-murray
       - bigludo7
       - sachinvodafone
       - akoshunyadi
   - api_name: device-roaming-status
-    target_api_version: 1.1.0
-    target_api_status: public
+    target_api_version: 1.2.0
+    target_api_status: rc
     main_contacts:
       - eric-murray
       - bigludo7


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* repository management


#### What this PR does / why we need it:

Announce that it is our intention that the next release be a part of the next meta-release (Sync26).



#### Which issue(s) this PR fixes:

Fixes # N/A

#### Special notes for reviewers:

For `device-roaming-status-subscriptions` the target is
```
    target_api_version: 0.9.0
    target_api_status: rc
```

For `device-roaming-status` it should be decided if new major version is needed.
Current setting is:

```
    target_api_version: 1.2.0
    target_api_status: rc
```

#### Changelog input

```
Update release plan for Sync26
```
#### Additional documentation
[CAMARA Release Process Documentation](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/README.md)
