### PR TITLE
fix: declare CloudEvent schema type

### DIFF
--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -866,6 +866,7 @@ components:
 
     CloudEvent:
       description: The notification callback
+      type: object
       required:
         - id
         - source


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Adds the missing `type: object` declaration to the `CloudEvent` schema in `device-roaming-status-subscriptions.yaml`.

This resolves the CAMARA Validation S-016 error reported on PR #75: `components.schemas.CloudEvent` must declare a type or combiner.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Scoped follow-up for the validation error seen on #75. Local Spectral r4 check reports 0 errors for the changed API definition; remaining findings are existing warnings/hints.

#### Changelog input

```
Fix CloudEvent schema type declaration in device-roaming-status-subscriptions
```

#### Additional documentation 

This section can be blank.

```
docs
```
