### PR TITLE
Make lastStatusTime nullable, and add an example

### DIFF
--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -205,6 +205,7 @@ paths:
                     countryCode: 340
                     countryName: ["BL", "GF", "GP", "MF", "MQ"]
                 Last Status Update Time Unknown:
+                  description: The API provider has recorded that the device is currently roaming, but has no information as to when that status was last confirmed to be correct. The API consumer must take this uncertainty into account when deciding on the value of the information to them.
                   value:
                     lastStatusTime: null
                     roaming: true

--- a/code/API_definitions/device-roaming-status.yaml
+++ b/code/API_definitions/device-roaming-status.yaml
@@ -204,6 +204,12 @@ paths:
                     roaming: true
                     countryCode: 340
                     countryName: ["BL", "GF", "GP", "MF", "MQ"]
+                Last Status Update Time Unknown:
+                  value:
+                    lastStatusTime: null
+                    roaming: true
+                    countryCode: 262
+                    countryName: ["DE"]
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -229,8 +235,11 @@ components:
       description: |
         The last time that the device roaming status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-      allOf:
-        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+      type: string
+      format: date-time
+      maxLength: 64
+      nullable: true
+      example: "2018-04-05T17:31:00Z"
 
     ActiveRoaming:
       description: Roaming status. True, if it is roaming

--- a/code/Test_definitions/device-roaming-status.feature
+++ b/code/Test_definitions/device-roaming-status.feature
@@ -35,7 +35,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.roaming" is "true"
     And the response property "$.countryCode" has the value "262" as the Mobile Country Code (MCC) for Germany
     And the response property "$.countryName" is a non-empty array containing the ISO 3166 ALPHA-2 country-code ["DE"]
-    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
+    And the response property "$.lastStatusTime" is present and either has a valid date-time format for a time in the past, or is null
 
   @device_roaming_status_02_roaming_status_false
   Scenario: Check the roaming state synchronously if the device is not in the roaming mode
@@ -50,7 +50,7 @@ Feature: CAMARA Device Roaming Status API, vwip - Operation getRoamingStatus
     And the response property "$.roaming" is "false"
     And the response property "$.countryCode" is not present
     And the response property "$.countryName" is not present
-    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
+    And the response property "$.lastStatusTime" is present and either has a valid date-time format for a time in the past, or is null
 
 #################
 # Error scenarios for management of input parameter device


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Allow lastStatusTime to be nullable, so that null can be provided as a value when the implementation has no clue when the roaming status they provide was confirmed to be correct. The API consumer must then decide for themselves whether the status provided is of any value to them.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #80 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Make lastStatusTime nullable, and add an example
```

#### Additional documentation 
None