### PR TITLE
[Fixed] Correct info.description documentation regarding identified device notification

### DIFF
--- a/code/API_definitions/device-roaming-status-subscriptions.yaml
+++ b/code/API_definitions/device-roaming-status-subscriptions.yaml
@@ -14,7 +14,7 @@ info:
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
 
-        At least one identifier for the device out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+        At least one identifier for the device out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the subscription creation response.
 
         Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Fixes copy/paste error in documentation, changing "session creation response" to "subscription creation response".

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #64

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - [Fixed] Correct info.description documentation regarding identified device notification
```

#### Additional documentation 
None